### PR TITLE
add cuda support - CUDA

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -471,8 +471,10 @@ std::string HelpMessage(HelpMessageMode mode)
 
 #ifdef ENABLE_GPU
     strUsage += HelpMessageOpt("-G", _("Enable GPU mining (default: false)"));
+    strUsage += HelpMessageOpt("-CUDA", _("Enable NVIDIA CUDA mining (default: false)"));
+    strUsage += HelpMessageOpt("-platform=<id>", _("If -G is enabled this specifies the GPU platform number to use (default: 0)"));
     strUsage += HelpMessageOpt("-device=<id>", _("If -G is enabled this specifies the GPU device number to use (default: 0)"));
-    strUsage += HelpMessageOpt("-allgpu", _("If -G is enabled this will mine on all available GPU devices (default: false)"));
+    strUsage += HelpMessageOpt("-allgpu", _("If -G is enabled this will mine on all available GPU platforms and devices (default: false)"));
     strUsage += HelpMessageOpt("-forcenolimit", _("Do not limit thread count per GPU by memory limits. (default: false)"));
 #endif
 #endif
@@ -1743,10 +1745,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 #ifdef ENABLE_WALLET
     // Generate coins in the background
     GPUConfig conf;
-    conf.selGPU = gArgs.GetArg("-deviceid", 0);
-    conf.allGPU = gArgs.GetBoolArg("-allgpu", 0);
+
     conf.forceGenProcLimit = gArgs.GetBoolArg("-forcenolimit", false);
+    conf.selGPU = gArgs.GetArg("-device", 0);
 #ifdef ENABLE_GPU    
+    conf.allGPU = gArgs.GetBoolArg("-allgpu", 0);
+    conf.sel_platform = gArgs.GetArg("-platform", 0);
+    conf.useCUDA   = gArgs.GetBoolArg("-CUDA", 0);
     conf.useGPU = gArgs.GetBoolArg("-G", false) || gArgs.GetBoolArg("-GPU", false);
 #else
     conf.useGPU = false;

--- a/src/libgpusolver/gpuconfig.h
+++ b/src/libgpusolver/gpuconfig.h
@@ -31,8 +31,10 @@ public:
     //~GPUConfig();
 
     bool useGPU;
+    unsigned sel_platform;
     unsigned selGPU;
     bool allGPU;
+    bool useCUDA;
     bool forceGenProcLimit;
     unsigned currentPlatform;
     unsigned currentDevice;


### PR DESCRIPTION
Some Nvidia cards don't support CUDA, if we force all Nvidia machine start CUDA mining, this may fail some scenarios. We add -CUDA option in fabcoind, new CUDA  mining functions only work when starting with "-CUDA" option, else we still call OpenCL version.